### PR TITLE
refactor parser for literal unit

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -69,6 +69,7 @@ literal:
   | LITBOOL                             { LitBool($1) }
   | LITSTRING                           { LitString($1) }
   | LITCHAR                             { LitChar($1) }
+  | LEFT_PAREN RIGHT_PAREN              { LitUnit }
 
 list_literal:
     /* empty list */        { [] } 
@@ -83,7 +84,6 @@ atom:
   | var { $1 }
   | LEFT_PAREN expr COLON typ RIGHT_PAREN { Annotation($2, $4) }
   | LEFT_PAREN expr RIGHT_PAREN { $2 }
-  | LEFT_PAREN RIGHT_PAREN { Lit(LitUnit) }
 
 expr:
     NOT expr         { UnaryOp(Not, $2) }

--- a/test/ir/def.ml
+++ b/test/ir/def.ml
@@ -1,7 +1,5 @@
 open Pocaml.Print_ir
 
-(* open Pocaml.Parser *)
-(* open Pocaml.Lexer *)
 
 let%expect_test _ =
   print_prog "let fn (a: int) : int = 3";
@@ -38,3 +36,7 @@ let%expect_test _ =
 let%expect_test _ =
   print_prog "let a = [1;2;3;]";
   [%expect {| let a = ( [( 1 : None );( 2 : None );( 3 : None )] : None ) |}]
+
+let%expect_test _ =
+  print_prog "let a: () = ()";
+  [%expect {| let a = ( () : unit ) |}]


### PR DESCRIPTION
Moved rule for parsing unit from the atom rule to literal rule.