### PR TITLE
fix lifting nested and top-level lambdas

### DIFF
--- a/lib/lambda_lift.ml
+++ b/lib/lambda_lift.ml
@@ -46,7 +46,12 @@ let add_formal (lambda : expr) (var : expr) =
 *)
 let rec lift (p : program) (ctx : expr list) = function
   | Lambda (ty, id, e) ->
-      let e', p' = lift p ctx e in
+      let rec get_id_typ = function
+        | TArrow(a,b) -> get_id_typ a
+        | ty -> ty
+      in
+      let id_typ = get_id_typ ty in
+      let e', p' = lift p (Var(id_typ, id) :: ctx) e in
       let l = Lambda (ty, id, e') in
       (* add closure as parameters to lambda *)
       let lambda_with_closure = List.fold_left add_formal l ctx in

--- a/lib/lambda_lift.ml
+++ b/lib/lambda_lift.ml
@@ -42,37 +42,46 @@ let add_formal (lambda : expr) (var : expr) =
 
 (*
    function lift:
-   Ir.program -> Ir.expr list -> Ir.expr -> (Ir.expr * Ir.program)
+   bool -> Ir.program -> Ir.expr list -> Ir.expr -> (Ir.expr * Ir.program)
+
+   switch (bool)
+    - avoid lifing nested lambdas: we turn off switch when we recursivly
+      lift lambda in expr inside a Lambda
+    - avoid lifting top-level lambdas: turn off switch when we lift expr inside
+      a top-level declaration
 *)
-let rec lift (p : program) (ctx : expr list) = function
+let rec lift switch (p : program) (ctx : expr list) = function
   | Lambda (ty, id, e) ->
       let rec get_id_typ = function
         | TArrow(a,b) -> get_id_typ a
         | ty -> ty
       in
       let id_typ = get_id_typ ty in
-      let e', p' = lift p (Var(id_typ, id) :: ctx) e in
+      let e', p' = lift false p (Var(id_typ, id) :: ctx) e in
       let l = Lambda (ty, id, e') in
-      (* add closure as parameters to lambda *)
-      let lambda_with_closure = List.fold_left add_formal l ctx in
-      let lambda_name = fresh_lambda_name () in
-      (* create a global definition *)
-      let lifted_lambda_def = Def (lambda_name, lambda_with_closure) in
-      let lifted_lambda_var =
-        Var (typ_of_expr lambda_with_closure, lambda_name)
-      in
-      (* substitute original lambda with named function applied with params in closure *)
-      let new_expr = List.fold_left apply_actual lifted_lambda_var ctx in
-      (* update global definition *)
-      let defs = match p' with Program ds -> ds in
-      (new_expr, Program (lifted_lambda_def :: defs))
+      if switch then
+        (* add closure as parameters to lambda *)
+        let lambda_with_closure = List.fold_left add_formal l ctx in
+        let lambda_name = fresh_lambda_name () in
+        (* create a global definition *)
+        let lifted_lambda_def = Def (lambda_name, lambda_with_closure) in
+        let lifted_lambda_var =
+          Var (typ_of_expr lambda_with_closure, lambda_name)
+        in
+        (* substitute original lambda with named function applied with params in closure *)
+        let new_expr = List.fold_left apply_actual lifted_lambda_var ctx in
+        (* update global definition *)
+        let defs = match p' with Program ds -> ds in
+        (new_expr, Program (lifted_lambda_def :: defs))
+      else
+        (l, p')
   | Letin (ty, id, e1, e2) ->
-      let e1', p1 = lift p ctx e1 in
-      let e2', p2 = lift p1 (Var (typ_of_expr e1, id) :: ctx) e2 in
+      let e1', p1 = lift true p ctx e1 in
+      let e2', p2 = lift true p1 (Var (typ_of_expr e1, id) :: ctx) e2 in
       (Letin (ty, id, e1', e2'), p2)
   | Apply (ty, e1, e2) ->
-      let e1', p1 = lift p ctx e1 in
-      let e2', p2 = lift p1 ctx e2 in
+      let e1', p1 = lift true p ctx e1 in
+      let e2', p2 = lift true p1 ctx e2 in
       (Apply (ty, e1', e2'), p2)
   | Match (ty, e1, cases) ->
     (*
@@ -91,10 +100,10 @@ let rec lift (p : program) (ctx : expr list) = function
           | PatConsEnd (ty, id) -> List.rev (Var (ty, id) :: ctx)
         in
         let ctx' = update_ctx ctx pat in
-        let e', p' = lift p ctx' e in
+        let e', p' = lift true p ctx' e in
         (p', ctx, (pat, e') :: lst)
       in
-      let e1', p' = lift p ctx e1 in
+      let e1', p' = lift true p ctx e1 in
       let p'', _, cases' =
         List.fold_left lift_lambda_in_case (p', ctx, []) cases
       in
@@ -108,7 +117,7 @@ let lambda_lift (p : program) =
   let defs = extract_defs p in
   let lift_def (p : program) (d : definition) =
     let id, e = match d with Def (id, e) -> (id, e) in
-    let e', p' = lift p [] e in
+    let e', p' = lift false p [] e in
     let defs = extract_defs p' in
     let new_def = Def (id, e') in
     (* defs are in reverse order *)

--- a/test/ir/lambda_lift.ml
+++ b/test/ir/lambda_lift.ml
@@ -13,30 +13,26 @@ let%expect_test "lift lambdas in list" =
   [%expect {|
     let L1 = ( ( fun a -> ( a : int ) ) : int -> None )
     let L2 = ( ( fun b -> ( b : int ) ) : int -> None )
-    let lambda_list = ( ( ( ( ( :: : None ) ( L1 : int -> None ) ) : None ) ( ( ( ( ( :: : None ) ( L2 : int -> None ) ) : None ) ( [] : None ) ) : None ) ) : int -> int ) |}]
+    let lambda_list = ( ( ( ( ( _cons : None ) ( L1 : int -> None ) ) : None ) ( ( ( ( ( _cons : None ) ( L2 : int -> None ) ) : None ) ( [] : None ) ) : None ) ) : int -> int ) |}]
 
 let%expect_test "lift lambdas in letin expression" =
   print_prog_ll "let (a : int -> int) = let a = (3 : int) in (fun (b: int) -> ((b : int) + (a : int) : int) : int -> int)";
   [%expect {|
-    let L3 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( + : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : int -> int ) ) : int -> None -> int )
+    let L3 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : int -> int ) ) : int -> None -> int )
     let a = ( let ( a : int -> int ) = ( 3 : int ) in ( ( ( L3 : int -> None -> int ) ( a : int ) ) : int -> None ) ) |}]
 
 let%expect_test "lift lambdas in letin expression 2" =
   print_prog_ll " let f = let a = 3 in (fun b -> let c = 6 in (fun d -> b : int -> int) : int -> int -> int)";
   [%expect {|
-    let L4 = ( ( fun d -> ( ( fun c -> ( ( fun a -> ( b : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None -> None )
-    let L5 = ( ( fun b -> ( ( fun a -> ( let ( c : None ) = ( 6 : None ) in ( ( ( ( ( L4 : None -> None -> None -> None ) ( c : None ) ) : None -> None -> None ) ( a : None ) ) : None -> None ) ) ) : None -> None ) ) : None -> None -> None )
+    let L4 = ( ( fun d -> ( ( fun c -> ( ( fun b -> ( ( fun a -> ( b : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None -> None ) ) : None -> None -> None -> None -> None )
+    let L5 = ( ( fun b -> ( ( fun a -> ( let ( c : None ) = ( 6 : None ) in ( ( ( ( ( ( ( L4 : None -> None -> None -> None -> None ) ( c : None ) ) : None -> None -> None -> None ) ( b : None ) ) : None -> None -> None ) ( a : None ) ) : None -> None ) ) ) : None -> None ) ) : None -> None -> None )
     let f = ( let ( a : None ) = ( 3 : None ) in ( ( ( L5 : None -> None -> None ) ( a : None ) ) : None -> None ) ) |}]
-
-let%expect_test "lift lambdas in letin expression 2" =
-  print_prog " let f = let a = 3 in (fun b -> let c = 6 in (fun d -> b : int -> int) : int -> int -> int)";
-  [%expect {| let f = ( let ( a : None ) = ( 3 : None ) in ( ( fun b -> ( let ( c : None ) = ( 6 : None ) in ( ( fun d -> ( b : None ) ) : None -> None ) ) ) : None -> None ) ) |}]
 
 let%expect_test "lift lambdas in match arms" =
   print_prog_ll "let a = match 3 with | 3 -> fun b -> b + 1 | 4 -> fun c -> c * c";
   [%expect {|
-    let L6 = ( ( fun b -> ( ( ( ( ( + : None ) ( b : None ) ) : None ) ( 1 : None ) ) : None ) ) : None -> None )
-    let L7 = ( ( fun c -> ( ( ( ( ( * : None ) ( c : None ) ) : None ) ( c : None ) ) : None ) ) : None -> None )
+    let L6 = ( ( fun b -> ( ( ( ( ( _add : None ) ( b : None ) ) : None ) ( 1 : None ) ) : None ) ) : None -> None )
+    let L7 = ( ( fun c -> ( ( ( ( ( _times : None ) ( c : None ) ) : None ) ( c : None ) ) : None ) ) : None -> None )
     let a = ( (
      match ( 3 : None ) with
     |  ( 3 : None ) -> ( L6 : None -> None )
@@ -53,8 +49,15 @@ let%expect_test "lift lambdas in expr being patterned match on" =
       : int)
   ";
   [%expect {|
-    let L8 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( + : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : None -> int ) ) : int -> None -> None )
+    let L8 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : None -> int ) ) : int -> None -> None )
     let a = ( (
      match ( let ( a : int -> int ) = ( 3 : None ) in ( ( ( L8 : int -> None -> None ) ( a : None ) ) : int -> None ) ) with
     |  ( U1 : None ) -> ( 0 : None )
     ) : int ) |}]
+
+  let%expect_test "lifting nested lambdas" =
+    print_prog_ll "let f a b = a + b";
+    [%expect {|
+      let L9 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( b : None ) ) : None ) ) : None -> None ) ) : None -> None -> None )
+      let L10 = ( ( fun a -> ( ( ( L9 : None -> None -> None ) ( a : None ) ) : None -> None ) ) : None -> None -> None )
+      let f = ( L10 : None -> None -> None ) |}]

--- a/test/ir/lambda_lift.ml
+++ b/test/ir/lambda_lift.ml
@@ -55,9 +55,13 @@ let%expect_test "lift lambdas in expr being patterned match on" =
     |  ( U1 : None ) -> ( 0 : None )
     ) : int ) |}]
 
-  let%expect_test "lifting nested lambdas" =
-    print_prog_ll "let f a b = a + b";
-    [%expect {|
-      let L9 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( b : None ) ) : None ) ) : None -> None ) ) : None -> None -> None )
-      let L10 = ( ( fun a -> ( ( ( L9 : None -> None -> None ) ( a : None ) ) : None -> None ) ) : None -> None -> None )
-      let f = ( L10 : None -> None -> None ) |}]
+let%expect_test "don't lift top level lambdas" =
+  print_prog_ll "let f a b = a + b";
+  [%expect {|
+    let f = ( ( fun a -> ( ( fun b -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( b : None ) ) : None ) ) : None -> None ) ) : None -> None -> None ) |}]
+  
+let%expect_test "don't lift immediately nested lambdas" =
+  print_prog_ll "let a = let a = 1 in fun b -> fun c -> a";
+  [%expect {|
+    let L9 = ( ( fun b -> ( ( fun c -> ( ( fun a -> ( a : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None )
+    let a = ( let ( a : None ) = ( 1 : None ) in ( ( ( L9 : None -> None -> None ) ( a : None ) ) : None -> None ) ) |}]


### PR DESCRIPTION
Previously
- forgot to pass in the formal parameter of upper level lambdas into the context/closure of the nested lambdas
- lifted both top-level and immediately nested lambdas

This commit fixes these issues. Test cases are updated to include test case for top-level and immediately nested lambda:

```ocaml
let%expect_test "don't lift top level lambdas" =
  print_prog_ll "let f a b = a + b";
  [%expect {|
    let f = ( ( fun a -> ( ( fun b -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( b : None ) ) : None ) ) : None -> None ) ) : None -> None -> None ) |}]
  
let%expect_test "don't lift immediately nested lambdas" =
  print_prog_ll "let a = let a = 1 in fun b -> fun c -> a";
  [%expect {|
    let L9 = ( ( fun b -> ( ( fun c -> ( ( fun a -> ( a : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None )
    let a = ( let ( a : None ) = ( 1 : None ) in ( ( ( L9 : None -> None -> None ) ( a : None ) ) : None -> None ) ) |}]
```