### PR TITLE
fix bug in lambda lifting

### DIFF
--- a/lib/lambda_lift.ml
+++ b/lib/lambda_lift.ml
@@ -11,20 +11,20 @@ let extract_defs = function Program defs -> defs
 
 (* creates an application of var to a lambda *)
 let apply_actual (e : expr) (var : expr) =
-  let l_type =
+  let typ_after_app =
     match typ_of_expr e with
-    | TArrow (t1, _) -> t1
+    | TArrow (_, t1) -> t1
     | ty ->
         error
           ("[ Lambda_lift.apply_actual ] apply " ^ string_of_expr var
          ^ " to expr (" ^ string_of_expr e
          ^ ") : expected type TArrow, but has " ^ string_of_typ ty)
   in
-  Apply (l_type, e, var)
+  Apply (typ_after_app, e, var)
 
-let rec add_formal_helper (formal : string) (formal_t : typ) = function
-  | Lambda (ty, id, body) ->
-      Lambda (TArrow (ty, formal_t), id, add_formal_helper formal formal_t body)
+let add_formal_helper (formal : string) (formal_t : typ) = function
+  | (Lambda (_, _, _)) as e ->
+      Lambda (TArrow(formal_t, typ_of_expr e), formal, e)
   | e -> Lambda (TArrow (formal_t, typ_of_expr e), formal, e)
 
 (* adds a formal parameter to a lambda to create a new lambda *)
@@ -44,7 +44,7 @@ let add_formal (lambda : expr) (var : expr) =
    function lift:
    bool -> Ir.program -> Ir.expr list -> Ir.expr -> (Ir.expr * Ir.program)
 
-   switch (bool)
+   switch (bool) determines if a lambda expression should be lifted
     - avoid lifing nested lambdas: we turn off switch when we recursivly
       lift lambda in expr inside a Lambda
     - avoid lifting top-level lambdas: turn off switch when we lift expr inside
@@ -69,7 +69,7 @@ let rec lift switch (p : program) (ctx : expr list) = function
           Var (typ_of_expr lambda_with_closure, lambda_name)
         in
         (* substitute original lambda with named function applied with params in closure *)
-        let new_expr = List.fold_left apply_actual lifted_lambda_var ctx in
+        let new_expr = List.fold_left apply_actual lifted_lambda_var (List.rev ctx) in
         (* update global definition *)
         let defs = match p' with Program ds -> ds in
         (new_expr, Program (lifted_lambda_def :: defs))

--- a/test/ast/expr.ml
+++ b/test/ast/expr.ml
@@ -10,11 +10,11 @@ let%expect_test "annotated variable" =
 
 let%expect_test "annotated expr with unary operator" =
   print_prog "let a = (not true : bool)";
-  [%expect {| let a = ( not true : bool ) |}]
+  [%expect {| let a = ( _not true : bool ) |}]
 
 let%expect_test "annotated expr with binary operator" =
   print_prog "let a = (3 + 5 : int)";
-  [%expect {| let a = ( ( 3 + 5 ) : int ) |}]
+  [%expect {| let a = ( ( 3 _add 5 ) : int ) |}]
 
 let%expect_test "annotated conditional expression" =
   print_prog "let a = (if true then 1 else 2 : int)";
@@ -27,7 +27,7 @@ let%expect_test "annotated let in expression" =
 let%expect_test "annotated lambda expression" =
   print_prog "let a = (fun (a: int) -> (a + 1 : int) : int -> int)";
   [%expect
-    {| let a = ( ( fun ( a : int ) = ( ( a + 1 ) : int ) ) : int -> int ) |}]
+    {| let a = ( ( fun ( a : int ) = ( ( a _add 1 ) : int ) ) : int -> int ) |}]
 
 let%expect_test "annotated function application" =
   print_prog "let a = (print \"hello\" : ())";

--- a/test/ir/def.ml
+++ b/test/ir/def.ml
@@ -35,7 +35,7 @@ let%expect_test _ =
 
 let%expect_test _ =
   print_prog "let a = [1;2;3;]";
-  [%expect {| let a = ( ( ( ( ( :: : None ) ( 1 : None ) ) : None ) ( ( ( ( ( :: : None ) ( 2 : None ) ) : None ) ( ( ( ( ( :: : None ) ( 3 : None ) ) : None ) ( [] : None ) ) : None ) ) : None ) ) : None ) |}]
+  [%expect {| let a = ( ( ( ( ( _cons : None ) ( 1 : None ) ) : None ) ( ( ( ( ( _cons : None ) ( 2 : None ) ) : None ) ( ( ( ( ( _cons : None ) ( 3 : None ) ) : None ) ( [] : None ) ) : None ) ) : None ) ) : None ) |}]
 
 let%expect_test _ =
   print_prog "let a: () = ()";

--- a/test/ir/expr.ml
+++ b/test/ir/expr.ml
@@ -10,11 +10,11 @@ let%expect_test "annotated variable" =
 
 let%expect_test "annotated expr with unary operator" =
   print_prog "let a = (not true : bool)";
-  [%expect {| let a = ( ( ( not : None ) ( true : None ) ) : bool ) |}]
+  [%expect {| let a = ( ( ( _not : None ) ( true : None ) ) : bool ) |}]
 
 let%expect_test "annotated expr with binary operator" =
   print_prog "let a = (3 + 5 : int)";
-  [%expect {| let a = ( ( ( ( ( + : None ) ( 3 : None ) ) : None ) ( 5 : None ) ) : int ) |}]
+  [%expect {| let a = ( ( ( ( ( _add : None ) ( 3 : None ) ) : None ) ( 5 : None ) ) : int ) |}]
 
 let%expect_test "annotated conditional expression" =
   print_prog "let a = (if true then 1 else 2 : int)";
@@ -32,7 +32,7 @@ let%expect_test "annotated let in expression" =
 let%expect_test "annotated lambda expression" =
   print_prog "let a = (fun (a: int) -> (a + 1 : int) : int -> int)";
   [%expect
-    {| let a = ( ( fun a -> ( ( ( ( ( + : None ) ( a : None ) ) : None ) ( 1 : None ) ) : int ) ) : int -> None ) |}]
+    {| let a = ( ( fun a -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( 1 : None ) ) : int ) ) : int -> None ) |}]
 
 let%expect_test "annotated function application" =
   print_prog "let a = (print (\"hello\" : string) : ())";

--- a/test/ir/lambda_lift.ml
+++ b/test/ir/lambda_lift.ml
@@ -18,21 +18,21 @@ let%expect_test "lift lambdas in list" =
 let%expect_test "lift lambdas in letin expression" =
   print_prog_ll "let (a : int -> int) = let a = (3 : int) in (fun (b: int) -> ((b : int) + (a : int) : int) : int -> int)";
   [%expect {|
-    let L3 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : int -> int ) ) : int -> None -> int )
-    let a = ( let ( a : int -> int ) = ( 3 : int ) in ( ( ( L3 : int -> None -> int ) ( a : int ) ) : int -> None ) ) |}]
+    let L3 = ( ( fun a -> ( ( fun b -> ( ( ( ( ( _add : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : int -> None ) ) : int -> int -> None )
+    let a = ( let ( a : int -> int ) = ( 3 : int ) in ( ( ( L3 : int -> int -> None ) ( a : int ) ) : int -> None ) ) |}]
 
 let%expect_test "lift lambdas in letin expression 2" =
   print_prog_ll " let f = let a = 3 in (fun b -> let c = 6 in (fun d -> b : int -> int) : int -> int -> int)";
   [%expect {|
-    let L4 = ( ( fun d -> ( ( fun c -> ( ( fun b -> ( ( fun a -> ( b : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None -> None ) ) : None -> None -> None -> None -> None )
-    let L5 = ( ( fun b -> ( ( fun a -> ( let ( c : None ) = ( 6 : None ) in ( ( ( ( ( ( ( L4 : None -> None -> None -> None -> None ) ( c : None ) ) : None -> None -> None -> None ) ( b : None ) ) : None -> None -> None ) ( a : None ) ) : None -> None ) ) ) : None -> None ) ) : None -> None -> None )
+    let L4 = ( ( fun a -> ( ( fun b -> ( ( fun c -> ( ( fun d -> ( b : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None -> None ) ) : None -> None -> None -> None -> None )
+    let L5 = ( ( fun a -> ( ( fun b -> ( let ( c : None ) = ( 6 : None ) in ( ( ( ( ( ( ( L4 : None -> None -> None -> None -> None ) ( a : None ) ) : None -> None -> None -> None ) ( b : None ) ) : None -> None -> None ) ( c : None ) ) : None -> None ) ) ) : None -> None ) ) : None -> None -> None )
     let f = ( let ( a : None ) = ( 3 : None ) in ( ( ( L5 : None -> None -> None ) ( a : None ) ) : None -> None ) ) |}]
 
 let%expect_test "lift lambdas in match arms" =
-  print_prog_ll "let a = match 3 with | 3 -> fun b -> b + 1 | 4 -> fun c -> c * c";
+  print_prog_ll "let a = match 3 with | 3 -> fun b -> b | 4 -> fun c -> c";
   [%expect {|
-    let L6 = ( ( fun b -> ( ( ( ( ( _add : None ) ( b : None ) ) : None ) ( 1 : None ) ) : None ) ) : None -> None )
-    let L7 = ( ( fun c -> ( ( ( ( ( _times : None ) ( c : None ) ) : None ) ( c : None ) ) : None ) ) : None -> None )
+    let L6 = ( ( fun b -> ( b : None ) ) : None -> None )
+    let L7 = ( ( fun c -> ( c : None ) ) : None -> None )
     let a = ( (
      match ( 3 : None ) with
     |  ( 3 : None ) -> ( L6 : None -> None )
@@ -43,25 +43,37 @@ let%expect_test "lift lambdas in expr being patterned match on" =
   print_prog_ll "
     let a = (
       match (let a = 3 in
-        (fun (b:int) -> ((b:int) + (a:int) : int) : int -> int)
+        (fun (b : int) -> (a : int) : int -> int)
         : int -> int)
       with | _ -> 0
       : int)
   ";
   [%expect {|
-    let L8 = ( ( fun b -> ( ( fun a -> ( ( ( ( ( _add : None ) ( b : int ) ) : None ) ( a : int ) ) : int ) ) : None -> int ) ) : int -> None -> None )
+    let L8 = ( ( fun a -> ( ( fun b -> ( a : int ) ) : int -> None ) ) : None -> int -> None )
     let a = ( (
-     match ( let ( a : int -> int ) = ( 3 : None ) in ( ( ( L8 : int -> None -> None ) ( a : None ) ) : int -> None ) ) with
+     match ( let ( a : int -> int ) = ( 3 : None ) in ( ( ( L8 : None -> int -> None ) ( a : None ) ) : int -> None ) ) with
     |  ( U1 : None ) -> ( 0 : None )
     ) : int ) |}]
 
 let%expect_test "don't lift top level lambdas" =
-  print_prog_ll "let f a b = a + b";
+  print_prog_ll "let f = fun a -> fun b -> a";
   [%expect {|
-    let f = ( ( fun a -> ( ( fun b -> ( ( ( ( ( _add : None ) ( a : None ) ) : None ) ( b : None ) ) : None ) ) : None -> None ) ) : None -> None -> None ) |}]
+    let f = ( ( fun a -> ( ( fun b -> ( a : None ) ) : None -> None ) ) : None -> None ) |}]
   
 let%expect_test "don't lift immediately nested lambdas" =
   print_prog_ll "let a = let a = 1 in fun b -> fun c -> a";
   [%expect {|
-    let L9 = ( ( fun b -> ( ( fun c -> ( ( fun a -> ( a : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None )
+    let L9 = ( ( fun a -> ( ( fun b -> ( ( fun c -> ( a : None ) ) : None -> None ) ) : None -> None ) ) : None -> None -> None )
     let a = ( let ( a : None ) = ( 1 : None ) in ( ( ( L9 : None -> None -> None ) ( a : None ) ) : None -> None ) ) |}]
+
+let%expect_test "lift not immediately nested lambda" =
+  print_prog_ll "let f = fun a -> let b = 1 in fun c -> a";
+  [%expect {|
+    let L10 = ( ( fun a -> ( ( fun b -> ( ( fun c -> ( a : None ) ) : None -> None ) ) : None -> None -> None ) ) : None -> None -> None -> None )
+    let f = ( ( fun a -> ( let ( b : None ) = ( 1 : None ) in ( ( ( ( ( L10 : None -> None -> None -> None ) ( a : None ) ) : None -> None -> None ) ( b : None ) ) : None -> None ) ) ) : None -> None ) |}]
+
+let %expect_test "lift lambda in application" =
+  print_prog_ll "let a = ((fun a -> a) 3) + 4";
+  [%expect {|
+    let L11 = ( ( fun a -> ( a : None ) ) : None -> None )
+    let a = ( ( ( ( ( _add : None ) ( ( ( L11 : None -> None ) ( 3 : None ) ) : None ) ) : None ) ( 4 : None ) ) : None ) |}]


### PR DESCRIPTION
fixed bug:

- formal parameters are added in **reverse order** to create new lambda
- actuals are applied in **reverse order** to lifted lambdas

```ocaml
(* example *)
let f = let a = 1 in let b = 2 in fun c -> b

(* previously, reverse order *)
let L1 = fun a -> fun b -> fun c -> b
let f = let a = 1 in let b = 2 in L1 b a

(* now, correct order *)
let L1 = fun a -> fun b -> fun c -> b
let f = let a = 1 in let b = 2 in L1 a b
```