### PR TITLE
pattern-matching codegen in progress

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -121,7 +121,7 @@ let codegen (Program definitions) =
   (* This `lookup` is actually more complicated than just looking up the llvalue.
      Since LLVM globals are actually pointers to the values, we have to first load
      the globals into a local variable, and then use it accordingly. However,
-     the current hacky approach actually loads it everytime it is beging looked up,
+     the current hacky approach actually loads it everytime it is being looked up,
      so there could be multiple locals variables that point to the same global variable.
      It works, but we should probably think of something better. *)
   let lookup n builder env =
@@ -161,7 +161,20 @@ let codegen (Program definitions) =
             builder
         in
         (llval, builder)
-    | Match (t, e, arms) -> not_implemented ()
+    | Match (t, e, arms) -> 
+        let llval1, builder = build_expr f builder env e1 in
+        let pat_match = function
+          | (pat, e2) -> extract_pat pat 
+        and extract_pat = function 
+          | PatLit (t, lit) -> 
+          | PatCons (t, vid, vid) -> 
+          | PatConsEnd (t, vid) -> 
+          | PatDefault (t, vid) -> 
+        let matched = List.fliter pat_match arms in
+        let (_, em) = matched.hd in
+        build_expr f builder env em
+
+
   (* TODO *)
   and build_expr_lit builder = function
     | LitInt n ->

--- a/lib/lower_ast.ml
+++ b/lib/lower_ast.ml
@@ -15,7 +15,7 @@ let rec char_list_of_string = function
       String.get s 0
       :: char_list_of_string (String.sub s 1 (String.length s - 1))
 
-let frseh_if_wild = function "_" -> fresh_name () | s -> s
+let fresh_if_wild = function "_" -> fresh_name () | s -> s
 
 let rec annotate t1 t2 =
   match (t1, t2) with
@@ -84,7 +84,7 @@ and lower_conditional ann cond e1 e2 =
 and lower_letin ann var_id e1 e2 =
   I.Letin
     ( ann I.TNone,
-      frseh_if_wild var_id,
+      fresh_if_wild var_id,
       lower_expr no_annotation e1,
       lower_expr no_annotation e2 )
 
@@ -102,7 +102,7 @@ and lower_lambda ann aparams aoutput_typ abody =
   | ParamAnn (avar_id, _) :: aps ->
       I.Lambda
         ( lambda_ityp,
-          frseh_if_wild avar_id,
+          fresh_if_wild avar_id,
           lower_lambda no_annotation aps aoutput_typ abody )
 
 and lower_match ann e arms =
@@ -125,14 +125,14 @@ and lower_pat =
     | A.LitUnit -> error "Can't lower pattern matching on unit"
   in
   function
-  | A.PatId avar_id -> I.PatDefault (I.TNone, frseh_if_wild avar_id)
+  | A.PatId avar_id -> I.PatDefault (I.TNone, fresh_if_wild avar_id)
   | A.PatLit lit -> I.PatLit (I.TNone, lower_literal lit)
   | A.PatCons (pat1, pat2) -> (
       match (pat1, pat2) with
       | A.PatId avar_id1, A.PatId avar_id2 ->
-          I.PatCons (I.TNone, frseh_if_wild avar_id1, frseh_if_wild avar_id2)
+          I.PatCons (I.TNone, fresh_if_wild avar_id1, fresh_if_wild avar_id2)
       | A.PatId avar_id1, A.PatLit (A.LitList []) ->
-          I.PatConsEnd (I.TNone, frseh_if_wild avar_id1)
+          I.PatConsEnd (I.TNone, fresh_if_wild avar_id1)
       | _ -> error "Can't lower recursive patterns yet")
 
 and lower_lit ann alit =


### PR DESCRIPTION
This PR should contain the commits for implementation for the pattern-matching part of the code generation. 

The list of (pattern, e_match) tuples should be filtered by comparing the pattern with the expression (e1) that is being matched, and the variables included in the patterns will be added into the scope/env of e1 by modifying the corresponding string maps.  After the filtration, the head element = (_, e_match) will have its e_match evaluated.