### PR TITLE
implement builtin string_of_int

### DIFF
--- a/builtins/Makefile
+++ b/builtins/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-I.
+CFLAGS=-I. $(PML_CFLAGS)
 DEPS=buildins.h
 OBJ=_add.o \
  _and.o \

--- a/builtins/Makefile
+++ b/builtins/Makefile
@@ -19,7 +19,8 @@ OBJ=_add.o \
  _not_equal.o \
  _or.o \
  _seq.o \
- _times.o
+ _times.o \
+string_of_int.o
 
 .PHONY: default
 default: pml_builtins.a

--- a/builtins/_add.c
+++ b/builtins/_add.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include "builtins.h"
 
 
@@ -13,6 +14,11 @@ _pml_val _builtin__add(_pml_val *args)
 	right_operand = (_pml_int *) args[1];
 
 	*res = *left_operand + *right_operand;
+
+#ifdef BUILTIN_DEBUG
+	printf("[debug] %d + %d = %d\n", *left_operand, *right_operand, *res);
+#endif
+
 	return (_pml_val) res;
 }
 

--- a/builtins/_init.c
+++ b/builtins/_init.c
@@ -16,4 +16,5 @@ void _init__builtins()
     _init__and();
     _init__cons();
     _init__seq();
+    _init_string_of_int();
 }

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -4,11 +4,11 @@
 #include <stdint.h>
 
 /* pocaml primitives */
-typedef		int8_t		_pml_char;
+typedef		char		_pml_char;
 typedef		int8_t		_pml_bool;
 typedef		int8_t		_pml_unit;
 typedef		int32_t		_pml_int;
-typedef		int8_t		*_pml_string;
+typedef		_pml_char	*_pml_string;
 typedef		int8_t		*_pml_val;
 typedef		_pml_val	_pml_func(_pml_val*);
 typedef struct _pml_list_node {

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -9,7 +9,7 @@ typedef		int8_t		_pml_bool;
 typedef		int8_t		_pml_unit;
 typedef		int32_t		_pml_int;
 typedef		int8_t		*_pml_string;
-typedef		int8_t		*_pml_val; 
+typedef		int8_t		*_pml_val;
 typedef		_pml_val	_pml_func(_pml_val*);
 typedef struct _pml_list_node {
 	_pml_val data;
@@ -102,6 +102,10 @@ _pml_init _init__cons;
 _pml_func _builtin__seq;
 extern _pml_val _seq;
 _pml_init _init__seq;
+
+_pml_func _builtin_string_of_int;
+extern _pml_val string_of_int;
+_pml_init _init_string_of_int;
 
 _pml_init _init__builtins;
 

--- a/builtins/string_of_int.c
+++ b/builtins/string_of_int.c
@@ -18,7 +18,10 @@ _pml_val _builtin_string_of_int(_pml_val *args)
 	int_val = (_pml_int *) args[0];
 	sprintf(res, "%d", *int_val);
 
+#ifdef BUILTIN_DEBUG
 	printf("[debug] string_of_int %d -> %s\n", *int_val, res);
+#endif
+
 	return (_pml_val) res;
 }
 

--- a/builtins/string_of_int.c
+++ b/builtins/string_of_int.c
@@ -5,7 +5,7 @@
 
 
 #define	INT_MAX_CHAR_NUM    10
-#define INT_STR_MAX_SIZE    (sizeof(char) * INT_MAX_CHAR_NUM)
+#define INT_STR_MAX_SIZE    (sizeof(_pml_char) * INT_MAX_CHAR_NUM)
 
 
 _pml_val string_of_int;

--- a/builtins/string_of_int.c
+++ b/builtins/string_of_int.c
@@ -1,0 +1,28 @@
+
+#include <stdlib.h>
+#include <stdio.h>
+#include "builtins.h"
+
+
+#define	INT_MAX_CHAR_NUM    10
+#define INT_STR_MAX_SIZE    (sizeof(char) * INT_MAX_CHAR_NUM)
+
+
+_pml_val string_of_int;
+
+_pml_val _builtin_string_of_int(_pml_val *args)
+{
+	_pml_int *int_val;
+	_pml_string res = (_pml_string) malloc(INT_STR_MAX_SIZE);
+
+	int_val = (_pml_int *) args[0];
+	sprintf(res, "%d", *int_val);
+
+	printf("[debug] string_of_int %d -> %s\n", *int_val, res);
+	return (_pml_val) res;
+}
+
+void _init_string_of_int()
+{
+	string_of_int = _make_closure(_builtin_string_of_int, 1);
+}

--- a/lib/builtins.ml
+++ b/lib/builtins.ml
@@ -15,4 +15,5 @@ let builtin_names =
     "_and";
     "_cons";
     "_seq";
+    "string_of_int"
   ]

--- a/pocamlc
+++ b/pocamlc
@@ -50,7 +50,7 @@ rm -rf $build_dir
 mkdir $build_dir
 
 # copy source file to build_dir
-cp $1 ${build_dir}/${fname}.orig
+cp ${fname} ${build_dir}/${fname}.orig
 
 # prepend prelude
 fname_with_prelude=${build_dir}/${fname}

--- a/pocamlc
+++ b/pocamlc
@@ -1,22 +1,53 @@
 set -e
 
-fname=$1
+usage()
+{
+  echo "usage: pocamlc [-d] -f <path_to_pml_file>"
+  echo
+  echo "options:"
+  echo "-c	Clean C object files from previous build before rebuild."
+  echo "-d	Compile Pocaml C builtins with debugging information."
+  echo "-h	Display pocamlc usage."
+}
+
+
+CLEAN_PREV_BUILD=false
+POCAMLC_FLAGS=""
+fname=""
+
+
+[[ $@ ]] || { usage; exit 1; }
+while getopts 'cdf:h' opt; do
+  case $opt in
+    c) CLEAN_PREV_BUILD=true;;
+    d) POCAMLC_FLAGS+=" -D BUILTIN_DEBUG" ;;
+    f) fname=$OPTARG ;;
+    h | *) usage
+       exit ;;
+  esac
+done
+
+
 basename="${fname%.*}"
 build_dir="_pml_build"
 builtins_ar="pml_builtins.a"
+
 
 POCAML="dune exec -- bin/main.exe"
 LLI=lli
 LLC=llc
 CC=cc
 
+
 rm -rf $build_dir
 mkdir $build_dir
 
 $POCAML -c $fname > ${build_dir}/${basename}.ll
 
+
 cd builtins
-make  
+[ "$CLEAN_PREV_BUILD" = true ] && make clean
+make PML_CFLAGS="${POCAMLC_FLAGS}"
 cp ${builtins_ar} ../${build_dir}
 cd ..
 


### PR DESCRIPTION
@LeoQiao18 @jc4883 @yiming-fang Why are we using `int8_t` for all primitive values? Why didn't we use `char` for `_pml_char` for instance?