### PR TITLE
fix char and string parsing

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -21,8 +21,9 @@ let digit = ['0'-'9']
 let uppercase = ['A'-'Z']
 let lowercase = ['a'-'z']
 let letter = (uppercase | lowercase)
-let char_literal = (letter | "\\n" | "\\t")
-let string_literal = (letter | digit | '_' | '\'' | ' ' | '\\')
+let escaped_char = ("\\n" | "\\t" | "\'")
+let char_literal = ([^ '\''] | escaped_char )
+let string_literal = ([^ '"'] | "\\\"")+
 let id_literal = (letter | digit | '_' | '\'')
 (* TODO: fix var_id regex: support 'a *)
 let capitalized_ident = uppercase id_literal*
@@ -68,7 +69,7 @@ rule token = parse
 | "true"  { LITBOOL(true)  }
 | "false" { LITBOOL(false) }
 | integer_literal+ as lit { LITINT(int_of_string lit) }
-| '"' (string_literal+ as lit) '"'  { LITSTRING(lit) }
+| '"' (string_literal as lit) '"'  { LITSTRING(lit) }
 | '\''(char_literal as lit)'\'' { LITCHAR(lit) }
 | lowercase_ident as var { VARIABLE(var) }
 | eof { EOF }

--- a/pocamlc
+++ b/pocamlc
@@ -18,14 +18,16 @@ CC=cc
 
 usage()
 {
-  printf "usage: pocamlc [-cdrh] [-f] <path_to_pml_file>]"
-  printf
-  printf "options:"
-  printf "-c	Clean C object files from previous build before rebuild."
-  printf "-d	Compile Pocaml C builtins with debugging information."
-  printf "-r	Run the executable after compilation."
-  printf "-x	Clean and remove all build artifacts."
-  printf "-h	Display pocamlc usage."
+  echo
+  echo "usage: pocamlc [-cdrh] [-f] <path_to_pml_file>]"
+  echo
+  echo "options:"
+  echo "-c	Clean C object files from previous build before rebuild."
+  echo "-d	Compile Pocaml C builtins with debugging information."
+  echo "-r	Run the executable after compilation."
+  echo "-x	Clean and remove all build artifacts."
+  echo "-h	Display pocamlc usage."
+  echo
 }
 
 CLEAN_PREV_BUILD=false

--- a/test/pml/test_string_literal.pml
+++ b/test/pml/test_string_literal.pml
@@ -1,0 +1,8 @@
+let test_cases = [
+  "pocaml!";
+  "\tpocaml";
+  "x :: xs";
+  "\"quoted\""
+]
+
+let _ = map print_endline test_cases


### PR DESCRIPTION
The spec for acceptable character and string:
- char: enclosed in single quotes any non `'` character or escape sequence `\t`, `\n`, `\'`
- string: enclosed in double quotes any non `"` charater or the escape sequence `\"`

Added test cases for parsing string:

```ocaml
let test_cases = [
  "pocaml!";
  "\tpocaml";
  "x :: xs";
  "\"quoted\""
]

let _ = map print_endline test_cases
```

shell output:

```shell
➜ ./pocamlc -rf test/pml/test_string_literal.pml                                                                                                                                                         11:55:10 
make: Nothing to be done for `default'.
pocaml!
        pocaml
x :: xs
"quoted"
```


