### PR TITLE
regression test for pattern matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:focal
+ENV TZ=America/New_York
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -yq && \
+    apt-get upgrade -yq && \
+    apt-get install -yq --no-install-suggests --no-install-recommends \
+        ocaml \
+        menhir \
+        llvm-11 \
+        llvm-11-dev \
+        m4 \
+        git \
+        aspcud \
+        ca-certificates \
+        python2.7 \
+        pkg-config \
+        cmake \
+        opam && \
+    ln -s /usr/bin/lli-11 /usr/bin/lli && \
+    ln -s /usr/bin/llc-11 /usr/bin/llc
+
+RUN opam init --auto-setup --yes --disable-sandboxing
+
+WORKDIR '/pocaml'
+COPY ./pocaml.opam .
+RUN opam install . --deps-only --yes
+
+WORKDIR '/home/pocaml'
+
+ENTRYPOINT ["opam", "config", "exec", "--"]
+
+CMD ["bash"]

--- a/builtins/Makefile
+++ b/builtins/Makefile
@@ -23,6 +23,8 @@ OBJ= _init.o \
  _seq.o \
  _times.o \
  string_of_int.o \
+ string_of_bool.o \
+ string_of_char.o \
  print_string.o
 
 .PHONY: default

--- a/builtins/_init.c
+++ b/builtins/_init.c
@@ -17,5 +17,7 @@ void _init__builtins()
     _init__cons();
     _init__seq();
     _init_string_of_int();
+    _init_string_of_char();
+    _init_string_of_bool();
     _init_print_string();
 }

--- a/builtins/_pattern_match.c
+++ b/builtins/_pattern_match.c
@@ -35,6 +35,11 @@ _pml_bool _match_pat_lit_string(_pml_val val, _pml_string pat) {
     return strcmp(s, pat) == 0;
 }
 
+_pml_bool _match_pat_lit_unit(_pml_val val, _pml_unit pat) {
+    _pml_unit u = *((_pml_unit *) val);
+    return u == pat;
+}
+
 _pml_bool _match_pat_lit_list_end(_pml_val val) {
     return val == NULL;
 }

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -127,6 +127,14 @@ _pml_func _builtin_string_of_int;
 extern _pml_val string_of_int;
 _pml_init _init_string_of_int;
 
+_pml_func _builtin_string_of_char;
+extern _pml_val string_of_char;
+_pml_init _init_string_of_char;
+
+_pml_func _builtin_string_of_bool;
+extern _pml_val string_of_bool;
+_pml_init _init_string_of_bool;
+
 _pml_func _builtin_print_string;
 extern _pml_val print_string;
 _pml_init _init_print_string;

--- a/builtins/builtins.h
+++ b/builtins/builtins.h
@@ -59,6 +59,7 @@ _pml_bool _match_pat_lit_int(_pml_val val, _pml_int pat);
 _pml_bool _match_pat_lit_char(_pml_val val, _pml_char pat);
 _pml_bool _match_pat_lit_bool(_pml_val val, _pml_bool pat);
 _pml_bool _match_pat_lit_string(_pml_val val, _pml_string pat);
+_pml_bool _match_pat_lit_unit(_pml_val val, _pml_unit pat);
 _pml_bool _match_pat_lit_list_end(_pml_val val);
 _pml_val _list_get_head(_pml_val val);
 _pml_val _list_get_tail(_pml_val val);

--- a/builtins/string_of_bool.c
+++ b/builtins/string_of_bool.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "builtins.h"
 
-#define BOOL_NUM_CHAR    5
+#define BOOL_NUM_CHAR    6
 #define BOOL_STR_SIZE    (sizeof(_pml_char) * BOOL_NUM_CHAR)
 
 
@@ -18,7 +18,7 @@ _pml_val _builtin_string_of_bool(_pml_val *args)
 	if (*bool_val) {
 		bool_str = "true";
 	}
-	snprintf(res, "%s", bool_str);
+	sprintf(res, "%s", bool_str);
 
 #ifdef BUILTIN_DEBUG
 	printf("[debug] string_of_bool %d -> %s\n", *bool_val, res);

--- a/builtins/string_of_char.c
+++ b/builtins/string_of_char.c
@@ -2,16 +2,19 @@
 #include <stdio.h>
 #include "builtins.h"
 
+#define	CHAR_MAX_CHAR_NUM    2
+#define CHAR_STR_MAX_SIZE    (sizeof(_pml_char) * CHAR_MAX_CHAR_NUM)
 
 _pml_val string_of_char;
 
 _pml_val _builtin_string_of_char(_pml_val *args)
 {
 	_pml_char *char_val;
-	_pml_string res = (_pml_string) malloc(sizeof(_pml_char));
+	_pml_string res = (_pml_string) malloc(CHAR_STR_MAX_SIZE);
 
 	char_val = (_pml_char *) args[0];
-	snprintf(res, "%c", *char_val);
+	res[0] = *char_val;
+	res[1] = '\0';
 
 #ifdef BUILTIN_DEBUG
 	printf("[debug] string_of_char %c -> %s\n", *char_val, res);

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -50,6 +50,7 @@ and expr =
   | Conditional of expr * expr * expr
   | Letin of var_id * expr * expr
   | Lambda of param list * expr
+  | Function of (pat * expr) list
   | Apply of expr * expr
   | Match of expr * (pat * expr) list
   | Annotation of expr * typ

--- a/lib/builtins.ml
+++ b/lib/builtins.ml
@@ -16,5 +16,7 @@ let builtin_names =
     "_cons";
     "_seq";
     "string_of_int";
+    "string_of_bool";
+    "string_of_char";
     "print_string"
   ]

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -84,6 +84,12 @@ let codegen (Program definitions) =
     L.declare_function "_match_pat_lit_string" ftype the_module
   in
 
+  let match_pat_lit_unit_f =
+    let ftype = L.function_type pml_bool_t [| pml_val_t; pml_unit_t |] in
+    L.declare_function "_match_pat_lit_unit" ftype the_module
+  in
+
+
   let match_pat_lit_list_end_f =
     let ftype = L.function_type pml_bool_t [| pml_val_t |] in
     L.declare_function "_match_pat_lit_list_end" ftype the_module
@@ -248,7 +254,7 @@ let codegen (Program definitions) =
                           "match_result" match_builder
                     | LitChar c ->
                         let llval = L.const_int pml_char_t (Char.code c) in
-                        L.build_call match_pat_lit_int_f [| e'; llval |]
+                        L.build_call match_pat_lit_char_f [| e'; llval |]
                           "match_result" match_builder
                     | LitString s ->
                         let llval = L.build_global_stringptr s "" builder in
@@ -258,7 +264,10 @@ let codegen (Program definitions) =
                         let llval = L.const_int pml_bool_t (Bool.to_int b) in
                         L.build_call match_pat_lit_bool_f [| e'; llval |]
                           "match_result" match_builder
-                    | LitUnit -> L.const_int pml_bool_t (Bool.to_int true)
+                    | LitUnit ->
+                        let llval = L.const_int pml_unit_t 69 in
+                        L.build_call match_pat_lit_unit_f [| e'; llval |]
+                          "match_result" match_builder
                     | LitListEnd ->
                         L.build_call match_pat_lit_list_end_f [| e' |]
                           "match_result" match_builder)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -24,7 +24,7 @@ let letter = (uppercase | lowercase)
 let escaped_char = ("\\n" | "\\t" | "\'")
 let char_literal = ([^ '\''] | escaped_char )
 let string_literal = ([^ '"'] | "\\\"")+
-let id_literal = (letter | digit | '_' | '\'')
+let id_literal = (letter | digit | '_')
 (* TODO: fix var_id regex: support 'a *)
 let capitalized_ident = uppercase id_literal*
 let lowercase_ident = ('_' | (lowercase) id_literal*)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -52,6 +52,7 @@ rule token = parse
 | "let" { LET }
 | "in"  { IN }
 | "fun" { FUN }
+| "function" { FUNCTION }
 | "rec"   { REC }
 | "match" { MATCH }
 | "with"  { WITH }

--- a/lib/lower_ast.ml
+++ b/lib/lower_ast.ml
@@ -53,9 +53,18 @@ and lower_expr ann = function
   | A.Conditional (cond, e1, e2) -> lower_conditional ann cond e1 e2
   | A.Letin (avar_id, e1, e2) -> lower_letin ann avar_id e1 e2
   | A.Lambda (ps, e) -> lower_lambda ann ps A.TNone e
+  | A.Function arms -> lower_function ann arms
   | A.Apply (e1, e2) -> lower_apply ann e1 e2
   | A.Match (e, arms) -> lower_match ann e arms
   | A.Annotation (e, t) -> lower_expr (annotate (ann (lower_typ t))) e
+
+and lower_function ann arms =
+  let n = fresh_name () in
+  let match' = lower_match no_annotation (A.Var n) arms in
+  I.Lambda
+    ( ann I.TNone,
+      n,
+      match')
 
 and lower_unary_op ann aop e =
   I.Apply

--- a/lib/lower_ast.ml
+++ b/lib/lower_ast.ml
@@ -121,8 +121,8 @@ and lower_pat =
     | A.LitBool b -> I.LitBool b
     | A.LitList [] -> I.LitListEnd
     | A.LitList _ -> error "Can't lower pattern matching on non-emtpy list"
-    | A.LitString _ -> error "Can't lower pattern matching on string"
-    | A.LitUnit -> error "Can't lower pattern matching on unit"
+    | A.LitString s -> I.LitString s
+    | A.LitUnit -> I.LitUnit
   in
   function
   | A.PatId avar_id -> I.PatDefault (I.TNone, fresh_if_wild avar_id)

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -20,14 +20,14 @@
 %token PLUS MINUS TIMES DIVIDE LT LE GT GE EQ NE OR AND CONS 
 %token IF THEN ELSE                                          
 %token LET IN                                               
-%token FUN REC                                                
+%token FUN REC FUNCTION
 %token MATCH WITH PIPE                                      
 %token ARROW
 %token LEFT_PAREN RIGHT_PAREN
 %token COLON
 %token SEQ LSEP
 
-%nonassoc LET IN FUN MATCH WITH ARROW
+%nonassoc LET IN FUN MATCH WITH ARROW FUNCTION
 %left PIPE
 %left SEQ
 %right LSEP
@@ -117,14 +117,19 @@ expr:
   | LET VARIABLE EQ expr IN expr { Letin($2, $4, $6) }
   | MATCH expr WITH match_arms { Match($2, $4) }
   | FUN params ARROW expr { Lambda($2, $4) }
+  | FUNCTION match_arms { Function($2) }
   | apply { $1 }
 
 var:
   VARIABLE         { Var($1) }
 
 match_arms:
-    PIPE pat ARROW expr { [($2, $4)] }
-  | PIPE pat ARROW expr match_arms { ($2, $4) :: $5 }
+  | match_arms_                     { $1 }
+  | PIPE match_arms_                { $2 }
+
+match_arms_:
+  | pat ARROW expr                  { [($1, $3)] }
+  | pat ARROW expr PIPE match_arms_ { ($1, $3) :: $5 }
 
 pat:
   | pat_                           { $1 }

--- a/lib/print.ml
+++ b/lib/print.ml
@@ -51,6 +51,8 @@ let rec string_of_expr = function
       ^ " )"
   | Lambda (params, e) ->
       "( fun " ^ string_of_params params ^ " = " ^ string_of_expr e ^ " )"
+  | Function arms ->
+      "(\n function " ^ string_of_match_arms arms ^ "\n)"
   | Apply (e1, e2) -> "( " ^ string_of_expr e1 ^ " " ^ string_of_expr e2 ^ " )"
   | Match (e, lst) ->
       "(\n match " ^ string_of_expr e ^ " with\n" ^ string_of_match_arms lst

--- a/runDocker
+++ b/runDocker
@@ -1,0 +1,9 @@
+#!/bin/env bash
+
+docker_tag=pocaml/pocaml
+docker_work_dir=/home/pocaml
+
+docker_cmd_override=$*
+
+docker build -t $docker_tag .
+docker run -it -v "$(pwd)":"$docker_work_dir" -w="$docker_work_dir" $docker_tag $docker_cmd_override

--- a/stdlib/stdlib.pml
+++ b/stdlib/stdlib.pml
@@ -3,6 +3,8 @@ let print_endline s =
   print_string "\n"
 
 let print_int n = print_string (string_of_int n)
+let print_bool b = print_string (string_of_bool b)
+let print_char c = print_string (string_of_char c)
 
 let rec list_length = function [] -> 0 | _ :: xs -> 1 + list_length xs
 

--- a/stdlib/stdlib.pml
+++ b/stdlib/stdlib.pml
@@ -1,5 +1,29 @@
-let print_endline s = print_string s; print_string "\n"
+let print_endline s =
+  print_string s;
+  print_string "\n"
 
-let rec map f xs = match xs with
+let print_int n = print_string (string_of_int n)
+
+let rec list_length = function [] -> 0 | _ :: xs -> 1 + list_length xs
+
+let rec list_map f = function [] -> [] | x :: xs -> f x :: list_map f xs
+
+let rec list_iter f = function
+  | [] -> ()
+  | x :: xs ->
+      f x;
+      list_iter f xs
+
+let rec list_append xs ys =
+  match xs with [] -> ys | x :: xs -> x :: list_append xs ys
+
+let rec list_filter pred = function
   | [] -> []
-  | (x :: xs) -> f x :: map f xs
+  | x :: xs -> if pred x then x else list_filter pred xs
+
+let rec list_fold_left f m = function
+  | [] -> m
+  | x :: xs -> list_fold_left f (f m x) xs
+
+let list_rev xs =
+  list_fold_left (fun l x -> x :: l) [] xs

--- a/stupidlib/codegen.ml
+++ b/stupidlib/codegen.ml
@@ -85,6 +85,3 @@ let codegen () =
     L.build_ret (L.const_int i32_t 69) builder
   in
   the_module
-
-  match a with 
-  | 

--- a/test/pml/test_function_1.pml
+++ b/test/pml/test_function_1.pml
@@ -1,0 +1,8 @@
+let f = function
+    1 -> "1"
+  | 2 -> "2"
+  | _ -> "_"
+
+let _ = print_string "f 1 = "; print_endline (f 1)
+let _ = print_string "f 2 = "; print_endline (f 2)
+let _ = print_string "f others = "; print_endline (f 3)

--- a/test/pml/test_pattern_matching_1.pml
+++ b/test/pml/test_pattern_matching_1.pml
@@ -21,4 +21,4 @@ let lsts = [
   [2;1]
 ]
 
-let _ = map (fun lst -> print_endline (test_pattern_matching lst)) lsts
+let _ = list_map (fun lst -> print_endline (test_pattern_matching lst)) lsts

--- a/test/pml/test_pattern_matching_1.pml
+++ b/test/pml/test_pattern_matching_1.pml
@@ -1,0 +1,24 @@
+let test_pattern_matching lst =
+  match lst with
+    | x :: xs ->
+      match x with
+	  | 1	  -> "int    list   (1 :: ints)"
+	  | true  -> "bool   list   (true  :: bools)"
+	  | false -> "bool   list   (false :: bools)"
+	  | 'a'	  -> "char   list   ('a' :: chars)"
+	  | ()	  -> "unit   list"
+	  | "pml" -> "string list   (\"pml\" :: strings)"
+	  | _	  -> "other  list"
+    | [] -> "empty list ([])"
+
+let lsts = [
+  [1; 2];
+  [true; false];
+  [false; true];
+  ['a'; 'b'];
+  [()];
+  ["pml"; "cool"];
+  [2;1]
+]
+
+let _ = map (fun lst -> print_endline (test_pattern_matching lst)) lsts


### PR DESCRIPTION
Some tests failed, need to investigate:

```shell
➜ ./pocamlc -cf test/pml/test_pattern_matching_1.pml                                                                                                                                                     12:20:28 
Fatal error: exception Pocaml.Lower_ast.LowerAstError("Can't lower pattern matching on unit")

➜ ./pocamlc -cf test/pml/test_pattern_matching_1.pml                                                                                                                                                     
Fatal error: exception Pocaml.Lower_ast.LowerAstError("Can't lower pattern matching on string")

➜ ./pocamlc -cf test/pml/test_pattern_matching_1.pml                                                                                                                                                     
Call parameter type does not match function signature!
i8 97
 i32  %match_result11 = call i1 @_match_pat_lit_int(i8* %1, i8 97)
LLVM ERROR: Broken module found, compilation aborted!
./pocamlc: line 88: 42051 Abort trap: 6           $POCAML -c ${build_dir}/${fname} > ${build_dir}/${basename}.ll
```